### PR TITLE
Fix 2FA Cookie

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -142,7 +142,7 @@ func (m *Middleware) setCookie(c *fiber.Ctx, info *Info) error {
 	cookieDomain := m.Config.CookieDomain
 	secure := m.Config.CookieSecure
 	if cookieDomain == "auto" && c.Secure() {
-		cookieDomain = c.BaseURL()
+		cookieDomain = c.Hostname()
 		secure = true
 	}
 


### PR DESCRIPTION
- [+] fix(middleware): use c.Hostname() instead of c.BaseURL() to set cookie domain in auto mode