### PR TITLE
Improve Generate image for barcode/qrcode

### DIFF
--- a/2fa_test.go
+++ b/2fa_test.go
@@ -591,7 +591,7 @@ func TestMiddleware_GenerateBarcodePath_CustomImage(t *testing.T) {
 	}
 
 	// Store the 2FA information in the storage for the test account
-	// Note: This info manager is useful for writing tests during open-source development because Go has a rich ecosystem.
+	// Note: This info manager is useful for writing tests during open-source development because Go has a rich ecosystem and tooling unlike other language mostly is poor.
 	// It eliminates the need to spend money on renting a database solely for testing purposes.
 	info := &twofa.Info{
 		Secret: secret,

--- a/qrcode.go
+++ b/qrcode.go
@@ -17,9 +17,9 @@ import (
 // GenerateBarcodePath generates the QR code image for the 2FA secret key.
 func (m *Middleware) GenerateBarcodePath(c *fiber.Ctx) error {
 	// Get the account name from c.Locals using the specified context key
-	accountName, ok := c.Locals(m.Config.ContextKey).(string)
-	if !ok {
-		// If account name is not found, use a default value or return an error
+	accountName, ok := c.Locals(m.Config.AccountName).(string)
+	if !ok || accountName == "" {
+		// If account name is not found or is an empty string, use a default value
 		accountName = "gopher"
 	}
 


### PR DESCRIPTION
- [+] feat(2fa): add support for custom barcode/qrcode image
- [+] allow setting a custom image for the barcode/qrcode through the BarcodeImage field in the Config struct
- [+] update GenerateBarcodePath to use the custom image if provided
- [+] add test case TestMiddleware_GenerateBarcodePath_CustomImage to verify the custom image functionality
- [+] refactor(2fa): improve account name handling in GenerateBarcodePath
- [+] use the AccountName field from the Config struct to retrieve the account name from c.Locals
- [+] handle cases where the account name is not found or is an empty string by using a default value
- [+] test(2fa): enhance test coverage
- [+] add test case TestMiddleware_GenerateBarcodePath_CustomImage to verify the custom barcode/qrcode image functionality
- [+] update TestMiddleware_GenerateBarcodePath to use the JSONMarshal field from the Config struct for marshaling 2FA information