### PR TITLE
Update Benchmark

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,9 +5,7 @@
 package twofa_test
 
 import (
-	"fmt"
-	"io"
-	"net/http"
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -15,190 +13,373 @@ import (
 	twofa "github.com/H0llyW00dzZ/fiber2fa"
 	"github.com/bytedance/sonic"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
 	"github.com/gofiber/storage/memory/v2"
 	"github.com/xlzd/gotp"
 )
 
-func BenchmarSonicJSONkMiddleware_Handle(b *testing.B) {
+func BenchmarkJSONSonicMiddlewareWithInvalidCookie(b *testing.B) {
 	// Set up the storage with an in-memory store for simplicity
 	store := memory.New()
 	secret := gotp.RandomSecret(16)
+	app := fiber.New()
 
-	// Create a default Info struct and store it for Simulate State
-	info := twofa.Info{
-		ContextKey:     "gopherBenchmarkOTP1",
-		Secret:         secret,
-		CookieValue:    "",
-		ExpirationTime: time.Time{},
-	}
-	infoJSON, _ := sonic.Marshal(info)
-	_ = store.Set("gopherBenchmarkOTP1", infoJSON, 0) // Ignoring error for brevity
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("sonic_benchmark", "sonic_benchmark1234")
+		return c.Next()
+	})
 
-	// Define a middleware instance with default configuration
-	middleware := twofa.New(twofa.Config{
+	app.Use(twofa.New(twofa.Config{
 		Secret:        secret,
-		Storage:       store,
-		ContextKey:    "gopherBenchmarkOTP1",
-		RedirectURL:   "/2fa",
+		Issuer:        "gopher",
+		ContextKey:    "sonic_benchmark",
 		CookieMaxAge:  86400,
-		CookieName:    "twofa_cookie",
-		TokenLookup:   "header:Authorization",
+		Storage:       store,
 		JSONMarshal:   sonic.Marshal,
 		JSONUnmarshal: sonic.Unmarshal,
-	})
+	}))
 
-	// Create a new Fiber app and register the middleware
-	app := fiber.New()
-	app.Use(func(c *fiber.Ctx) error {
-		c.Locals("gopherBenchmarkOTP1", "gopherBenchmarkOTP1")
-		return c.Next()
-	})
-	app.Use(middleware)
-
-	// Define routes that will be used for testing
 	app.Get("/", func(c *fiber.Ctx) error {
-		return c.SendStatus(fiber.StatusOK)
-	})
-	app.Post("/", func(c *fiber.Ctx) error {
-		return c.SendStatus(fiber.StatusOK)
+		return c.SendString("Hello, World!")
 	})
 
-	// Generate a valid 2FA token
-	totp := gotp.NewDefaultTOTP(secret)
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set(fiber.HeaderCookie, "twofa_cookie=invalid-cookie-value")
 
-	// Define the token lookup scenarios
-	scenarios := []struct {
-		name           string
-		requestURL     string
-		requestMethod  string
-		requestBody    io.Reader
-		requestHeaders map[string]string
-		requestCookies []*http.Cookie
-		expectedStatus int
-	}{
-		{
-			name:          "Header",
-			requestURL:    "https://hack/",
-			requestMethod: "GET",
-			requestHeaders: map[string]string{
-				"Authorization": fmt.Sprintf("Bearer %s", totp.Now()),
-			},
-			expectedStatus: fiber.StatusOK,
-		},
-	}
-
-	// Run the benchmark scenarios in parallel
 	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			for _, scenario := range scenarios {
-				// Create a new HTTP request for each scenario
-				req := httptest.NewRequest(scenario.requestMethod, scenario.requestURL, scenario.requestBody)
-				for key, value := range scenario.requestHeaders {
-					req.Header.Set(key, value)
-				}
-				for _, cookie := range scenario.requestCookies {
-					req.AddCookie(cookie)
-				}
 
-				// Perform the request
-				resp, err := app.Test(req)
-				if err != nil {
-					b.Fatalf("Failed to perform request: %v", err)
-				}
-				resp.Body.Close()
-			}
-		}
-	})
+	for i := 0; i < b.N; i++ {
+		resp, _ := app.Test(req)
+		utils.AssertEqual(b, fiber.StatusUnauthorized, resp.StatusCode)
+	}
 }
 
-func BenchmarStdJSONkMiddleware_Handle(b *testing.B) {
+func BenchmarkJSONSonicWithValid2FA(b *testing.B) {
 	// Set up the storage with an in-memory store for simplicity
 	store := memory.New()
 	secret := gotp.RandomSecret(16)
-
-	// Create a default Info struct and store it for Simulate State
-	info := twofa.Info{
-		ContextKey:     "gopherBenchmarkOTP2",
-		Secret:         secret,
-		CookieValue:    "",
-		ExpirationTime: time.Time{},
-	}
-	infoJSON, _ := sonic.Marshal(info)
-	_ = store.Set("gopherBenchmarkOTP2", infoJSON, 0) // Ignoring error for brevity
-
-	// Define a middleware instance with default configuration
-	middleware := twofa.New(twofa.Config{
-		Secret:       secret,
-		Storage:      store,
-		ContextKey:   "gopherBenchmarkOTP2",
-		RedirectURL:  "/2fa",
-		CookieMaxAge: 86400,
-		CookieName:   "twofa_cookie",
-		TokenLookup:  "header:Authorization",
-	})
-
-	// Create a new Fiber app and register the middleware
 	app := fiber.New()
+
 	app.Use(func(c *fiber.Ctx) error {
-		c.Locals("gopherBenchmarkOTP2", "gopherBenchmarkOTP2")
+		c.Locals("sonic_benchmark", "sonic_benchmark1234")
 		return c.Next()
 	})
-	app.Use(middleware)
 
-	// Define routes that will be used for testing
+	twoFAConfig := twofa.Config{
+		Secret:        secret,
+		Issuer:        "gopher",
+		ContextKey:    "sonic_benchmark",
+		CookieMaxAge:  86400,
+		Storage:       store,
+		JSONMarshal:   sonic.Marshal,
+		JSONUnmarshal: sonic.Unmarshal,
+		TokenLookup:   "query:token",
+	}
+
+	twoFAMiddleware := &twofa.Middleware{Config: &twoFAConfig}
+
+	app.Use(twoFAMiddleware.Handle)
+
 	app.Get("/", func(c *fiber.Ctx) error {
-		return c.SendStatus(fiber.StatusOK)
-	})
-	app.Post("/", func(c *fiber.Ctx) error {
-		return c.SendStatus(fiber.StatusOK)
+		return c.SendString("Hello, World!")
 	})
 
 	// Generate a valid 2FA token
 	totp := gotp.NewDefaultTOTP(secret)
+	token := totp.Now()
 
-	// Define the token lookup scenarios
-	scenarios := []struct {
-		name           string
-		requestURL     string
-		requestMethod  string
-		requestBody    io.Reader
-		requestHeaders map[string]string
-		requestCookies []*http.Cookie
-		expectedStatus int
-	}{
-		{
-			name:          "Header",
-			requestURL:    "https://hack/",
-			requestMethod: "GET",
-			requestHeaders: map[string]string{
-				"Authorization": fmt.Sprintf("Bearer %s", totp.Now()),
-			},
-			expectedStatus: fiber.StatusOK,
-		},
+	// Create a valid 2FA cookie
+	cookieValue := twoFAMiddleware.GenerateCookieValue(time.Now().Add(time.Duration(86400) * time.Second))
+
+	// Store the 2FA information in the storage
+	info := &twofa.Info{
+		ContextKey:     "sonic_benchmark1234",
+		Secret:         secret,
+		CookieValue:    cookieValue,
+		ExpirationTime: time.Time{},
+	}
+	infoJSON, _ := twoFAConfig.JSONMarshal(info)
+	err := store.Set("sonic_benchmark1234", infoJSON, 0)
+	if err != nil {
+		b.Fatalf("Failed to store 2FA information: %v", err)
 	}
 
-	// Run the benchmark scenarios in parallel
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			for _, scenario := range scenarios {
-				// Create a new HTTP request for each scenario
-				req := httptest.NewRequest(scenario.requestMethod, scenario.requestURL, scenario.requestBody)
-				for key, value := range scenario.requestHeaders {
-					req.Header.Set(key, value)
-				}
-				for _, cookie := range scenario.requestCookies {
-					req.AddCookie(cookie)
-				}
+	req := httptest.NewRequest(fiber.MethodGet, "/?token="+token, nil)
+	req.Header.Set(fiber.HeaderCookie, "twofa_cookie="+cookieValue)
 
-				// Perform the request
-				resp, err := app.Test(req)
-				if err != nil {
-					b.Fatalf("Failed to perform request: %v", err)
-				}
-				resp.Body.Close()
-			}
-		}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		resp, _ := app.Test(req)
+		utils.AssertEqual(b, fiber.StatusOK, resp.StatusCode)
+	}
+}
+
+func BenchmarkJSONSonicWithValidCookie(b *testing.B) {
+	// Set up the storage with an in-memory store for simplicity
+	store := memory.New()
+	secret := gotp.RandomSecret(16)
+	app := fiber.New()
+
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("sonic_benchmark", "sonic_benchmark1234")
+		return c.Next()
 	})
+
+	twoFAConfig := twofa.Config{
+		Secret:        secret,
+		Issuer:        "gopher",
+		ContextKey:    "sonic_benchmark",
+		CookieMaxAge:  86400,
+		Storage:       store,
+		JSONMarshal:   sonic.Marshal,
+		JSONUnmarshal: sonic.Unmarshal,
+		TokenLookup:   "query:token",
+	}
+
+	twoFAMiddleware := &twofa.Middleware{Config: &twoFAConfig}
+
+	app.Use(twoFAMiddleware.Handle)
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	// Generate a valid 2FA token
+	totp := gotp.NewDefaultTOTP(secret)
+	token := totp.Now()
+
+	// Create a valid 2FA cookie
+	cookieValue := twoFAMiddleware.GenerateCookieValue(time.Now().Add(time.Duration(86400) * time.Second))
+
+	// Store the 2FA information in the storage
+	info := &twofa.Info{
+		ContextKey:     "sonic_benchmark1234",
+		Secret:         secret,
+		CookieValue:    cookieValue,
+		ExpirationTime: time.Time{},
+	}
+	infoJSON, _ := twoFAConfig.JSONMarshal(info)
+	err := store.Set("sonic_benchmark1234", infoJSON, 0)
+	if err != nil {
+		b.Fatalf("Failed to store 2FA information: %v", err)
+	}
+
+	// Create a request with the valid cookie
+	req := httptest.NewRequest(fiber.MethodGet, "/?token="+token, nil)
+	req.Header.Set(fiber.HeaderCookie, twoFAConfig.CookieName+"="+cookieValue)
+
+	// Perform the initial request to generate and store the 2FA information
+	resp, err := app.Test(req)
+	if err != nil {
+		b.Fatalf("Failed to perform initial request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Extract the generated cookie from the response
+	cookies := resp.Cookies()
+	for _, cookie := range cookies {
+		if cookie.Name == twoFAConfig.CookieName {
+			cookieValue = cookie.Value
+			break
+		}
+	}
+
+	if cookieValue == "" {
+		b.Fatalf("Failed to retrieve the generated cookie")
+	}
+
+	// Create a new request with the valid cookie
+	req = httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set(fiber.HeaderCookie, twoFAConfig.CookieName+"="+cookieValue)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		resp, _ := app.Test(req)
+		utils.AssertEqual(b, fiber.StatusOK, resp.StatusCode)
+	}
+}
+
+func BenchmarkJSONStdLibraryMiddlewareWithInvalidCookie(b *testing.B) {
+	// Set up the storage with an in-memory store for simplicity
+	store := memory.New()
+	secret := gotp.RandomSecret(16)
+	app := fiber.New()
+
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("stdlibrary_benchmark", "stdlibrary_benchmark1234")
+		return c.Next()
+	})
+
+	app.Use(twofa.New(twofa.Config{
+		Secret:        secret,
+		Issuer:        "gopher",
+		ContextKey:    "stdlibrary_benchmark",
+		CookieMaxAge:  86400,
+		Storage:       store,
+		JSONMarshal:   json.Marshal,
+		JSONUnmarshal: json.Unmarshal,
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set(fiber.HeaderCookie, "twofa_cookie=invalid-cookie-value")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		resp, _ := app.Test(req)
+		utils.AssertEqual(b, fiber.StatusUnauthorized, resp.StatusCode)
+	}
+}
+
+func BenchmarkJSONStdLibraryMiddlewareWithValid2FA(b *testing.B) {
+	// Set up the storage with an in-memory store for simplicity
+	store := memory.New()
+	secret := gotp.RandomSecret(16)
+	app := fiber.New()
+
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("stdlibrary_benchmark", "stdlibrary_benchmark1234")
+		return c.Next()
+	})
+
+	twoFAConfig := twofa.Config{
+		Secret:        secret,
+		Issuer:        "gopher",
+		ContextKey:    "stdlibrary_benchmark",
+		CookieMaxAge:  86400,
+		Storage:       store,
+		JSONMarshal:   json.Marshal,
+		JSONUnmarshal: json.Unmarshal,
+		TokenLookup:   "query:token",
+	}
+
+	twoFAMiddleware := &twofa.Middleware{Config: &twoFAConfig}
+
+	app.Use(twoFAMiddleware.Handle)
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	// Generate a valid 2FA token
+	totp := gotp.NewDefaultTOTP(secret)
+	token := totp.Now()
+
+	// Create a valid 2FA cookie
+	cookieValue := twoFAMiddleware.GenerateCookieValue(time.Now().Add(time.Duration(86400) * time.Second))
+
+	// Store the 2FA information in the storage
+	info := &twofa.Info{
+		ContextKey:     "stdlibrary_benchmark1234",
+		Secret:         secret,
+		CookieValue:    cookieValue,
+		ExpirationTime: time.Time{},
+	}
+	infoJSON, _ := twoFAConfig.JSONMarshal(info)
+	err := store.Set("stdlibrary_benchmark1234", infoJSON, 0)
+	if err != nil {
+		b.Fatalf("Failed to store 2FA information: %v", err)
+	}
+
+	req := httptest.NewRequest(fiber.MethodGet, "/?token="+token, nil)
+	req.Header.Set(fiber.HeaderCookie, "twofa_cookie="+cookieValue)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		resp, _ := app.Test(req)
+		utils.AssertEqual(b, fiber.StatusOK, resp.StatusCode)
+	}
+}
+
+func BenchmarkJSONStdLibraryWithValidCookie(b *testing.B) {
+	// Set up the storage with an in-memory store for simplicity
+	store := memory.New()
+	secret := gotp.RandomSecret(16)
+	app := fiber.New()
+
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("stdlibrary_benchmark", "stdlibrary_benchmark1234")
+		return c.Next()
+	})
+
+	twoFAConfig := twofa.Config{
+		Secret:        secret,
+		Issuer:        "gopher",
+		ContextKey:    "stdlibrary_benchmark",
+		CookieMaxAge:  86400,
+		Storage:       store,
+		JSONMarshal:   json.Marshal,
+		JSONUnmarshal: json.Unmarshal,
+		TokenLookup:   "query:token",
+	}
+
+	twoFAMiddleware := &twofa.Middleware{Config: &twoFAConfig}
+
+	app.Use(twoFAMiddleware.Handle)
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	// Generate a valid 2FA token
+	totp := gotp.NewDefaultTOTP(secret)
+	token := totp.Now()
+
+	// Create a valid 2FA cookie
+	cookieValue := twoFAMiddleware.GenerateCookieValue(time.Now().Add(time.Duration(86400) * time.Second))
+
+	// Store the 2FA information in the storage
+	info := &twofa.Info{
+		ContextKey:     "stdlibrary_benchmark1234",
+		Secret:         secret,
+		CookieValue:    cookieValue,
+		ExpirationTime: time.Time{},
+	}
+	infoJSON, _ := twoFAConfig.JSONMarshal(info)
+	err := store.Set("stdlibrary_benchmark1234", infoJSON, 0)
+	if err != nil {
+		b.Fatalf("Failed to store 2FA information: %v", err)
+	}
+
+	// Create a request with the valid cookie
+	req := httptest.NewRequest(fiber.MethodGet, "/?token="+token, nil)
+	req.Header.Set(fiber.HeaderCookie, twoFAConfig.CookieName+"="+cookieValue)
+
+	// Perform the initial request to generate and store the 2FA information
+	resp, err := app.Test(req)
+	if err != nil {
+		b.Fatalf("Failed to perform initial request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Extract the generated cookie from the response
+	cookies := resp.Cookies()
+	for _, cookie := range cookies {
+		if cookie.Name == twoFAConfig.CookieName {
+			cookieValue = cookie.Value
+			break
+		}
+	}
+
+	if cookieValue == "" {
+		b.Fatalf("Failed to retrieve the generated cookie")
+	}
+
+	// Create a new request with the valid cookie
+	req = httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set(fiber.HeaderCookie, twoFAConfig.CookieName+"="+cookieValue)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		resp, _ := app.Test(req)
+		utils.AssertEqual(b, fiber.StatusOK, resp.StatusCode)
+	}
 }


### PR DESCRIPTION
- [+] test(benchmark): add benchmarks for JSON marshaling and 2FA scenarios
- [+] The added benchmarks cover the following scenarios:
- [+] JSON marshaling using Sonic library with invalid cookie
- [+] JSON marshaling using Sonic library with valid 2FA
- [+] JSON marshaling using Sonic library with valid cookie
- [+] JSON marshaling using standard library with invalid cookie
- [+] JSON marshaling using standard library with valid 2FA
- [+] JSON marshaling using standard library with valid cookie
- [+] The benchmarks measure the performance of the middleware under different conditions, including invalid cookies, valid 2FA tokens, and valid cookies. They also compare the performance of using the Sonic library versus the standard JSON library for marshaling and unmarshaling.

Latest:

```
goos: windows
goarch: amd64
pkg: github.com/H0llyW00dzZ/fiber2fa
cpu: AMD Ryzen 9 3900X 12-Core Processor            
BenchmarkJSONSonicMiddlewareWithInvalidCookie-24         	  114559	      9657 ns/op	    6059 B/op	      29 allocs/op
BenchmarkJSONSonicWithValid2FA-24                        	   56224	     22300 ns/op	    9935 B/op	      69 allocs/op
BenchmarkJSONSonicWithValidCookie-24                     	  104232	     11566 ns/op	    6826 B/op	      41 allocs/op
BenchmarkJSONStdLibraryMiddlewareWithInvalidCookie-24    	  120128	      9791 ns/op	    5997 B/op	      29 allocs/op
BenchmarkJSONStdLibraryMiddlewareWithValid2FA-24         	   47682	     25747 ns/op	    8449 B/op	      71 allocs/op
BenchmarkJSONStdLibraryWithValidCookie-24                	  102794	     11619 ns/op	    6830 B/op	      41 allocs/op
```