### PR TITLE
Improve Performance

### DIFF
--- a/crypto_cookie.go
+++ b/crypto_cookie.go
@@ -13,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/gofiber/fiber/v2/utils"
 )
 
 // GenerateCookieValue generates a signed cookie value using HMAC.
@@ -25,10 +23,10 @@ import (
 // This will replace the current implementation that uses HMAC.
 func (m *Middleware) GenerateCookieValue(expirationTime time.Time) string {
 	data := fmt.Sprintf("%d", expirationTime.Unix())
-	hash := hmac.New(sha256.New, utils.CopyBytes([]byte(m.Config.Secret)))
-	hash.Write(utils.CopyBytes([]byte(data)))
-	signature := base64.RawURLEncoding.EncodeToString(utils.CopyBytes(hash.Sum(nil)))
-	return fmt.Sprintf("%s.%s", utils.CopyString(data), signature)
+	hash := hmac.New(sha256.New, []byte(m.Config.Secret))
+	hash.Write([]byte(data))
+	signature := base64.RawURLEncoding.EncodeToString(hash.Sum(nil))
+	return fmt.Sprintf("%s.%s", data, signature)
 }
 
 // validateCookie validates the cookie value using HMAC.
@@ -41,11 +39,11 @@ func (m *Middleware) validateCookie(cookie string) bool {
 	data := parts[0]
 	signature := parts[1]
 
-	hash := hmac.New(sha256.New, utils.CopyBytes([]byte(m.Config.Secret)))
-	hash.Write(utils.CopyBytes([]byte(data)))
+	hash := hmac.New(sha256.New, []byte(m.Config.Secret))
+	hash.Write([]byte(data))
 	expectedSignature := base64.RawURLEncoding.EncodeToString(hash.Sum(nil))
 
-	if subtle.ConstantTimeCompare(utils.CopyBytes([]byte(signature)), utils.CopyBytes([]byte(expectedSignature))) != 1 {
+	if subtle.ConstantTimeCompare([]byte(signature), []byte(expectedSignature)) != 1 {
 		return false
 	}
 

--- a/middleware.go
+++ b/middleware.go
@@ -157,7 +157,7 @@ func (m *Middleware) getContextKey(c *fiber.Ctx) (string, error) {
 
 // isValidCookie checks if the user has a valid 2FA cookie.
 func (m *Middleware) isValidCookie(c *fiber.Ctx, info *Info) bool {
-	cookie := utils.CopyString(c.Cookies(m.Config.CookieName))
+	cookie := c.Cookies(m.Config.CookieName)
 	if cookie == "" {
 		return false
 	}


### PR DESCRIPTION
Benchmark Result:

Before (using utils)
```
goos: windows
goarch: amd64
pkg: github.com/H0llyW00dzZ/fiber2fa
cpu: AMD Ryzen 9 3900X 12-Core Processor
BenchmarkJSONSonicMiddlewareWithInvalidCookie-24         	  103310	     10266 ns/op	    6065 B/op	      29 allocs/op
BenchmarkJSONSonicWithValid2FA-24                        	   56832	     21915 ns/op	    9777 B/op	      68 allocs/op
BenchmarkJSONSonicWithValidCookie-24                     	   91604	     12338 ns/op	    7562 B/op	      44 allocs/op
BenchmarkJSONStdLibraryMiddlewareWithInvalidCookie-24    	  126547	      9426 ns/op	    6000 B/op	      29 allocs/op
BenchmarkJSONStdLibraryMiddlewareWithValid2FA-24         	   50286	     24796 ns/op	    8244 B/op	      70 allocs/op
BenchmarkJSONStdLibraryWithValidCookie-24                	   58072	     19404 ns/op	    7272 B/op	      49 allocs/op
```
After (without utils)
```
goos: windows
goarch: amd64
pkg: github.com/H0llyW00dzZ/fiber2fa
cpu: AMD Ryzen 9 3900X 12-Core Processor
BenchmarkJSONSonicMiddlewareWithInvalidCookie-24         	  118537	      9420 ns/op	    6060 B/op	      29 allocs/op
BenchmarkJSONSonicWithValid2FA-24                        	   58778	     20506 ns/op	    9237 B/op	      66 allocs/op
BenchmarkJSONSonicWithValidCookie-24                     	   96550	     12558 ns/op	    7371 B/op	      41 allocs/op
BenchmarkJSONStdLibraryMiddlewareWithInvalidCookie-24    	  124382	      9629 ns/op	    6001 B/op	      29 allocs/op
BenchmarkJSONStdLibraryMiddlewareWithValid2FA-24         	   47356	     24286 ns/op	    8189 B/op	      68 allocs/op
BenchmarkJSONStdLibraryWithValidCookie-24                	   58508	     19867 ns/op	    7105 B/op	      46 allocs/op
```