### PR TITLE
Docs [2FA Internal] [Hash] [blake2botp] Update Documentation

### DIFF
--- a/internal/crypto/hash/blake2b.go
+++ b/internal/crypto/hash/blake2b.go
@@ -11,7 +11,7 @@ import (
 )
 
 // New512 returns a new instance of the Blake2botp hash with a 512-bit output size.
-// The returned hash implements the hash.Hash interface.
+// The returned hash implements the [hash.Hash] interface.
 func New512() hash.Hash {
 	h, _ := blake2b.New512(nil)
 	return &Blake2botp{
@@ -20,7 +20,7 @@ func New512() hash.Hash {
 }
 
 // Blake2botp is a struct that wraps the BLAKE2b hash function.
-// It implements the hash.Hash interface.
+// It implements the [hash.Hash] interface.
 type Blake2botp struct {
 	hash hash.Hash
 }

--- a/internal/crypto/hash/docs.go
+++ b/internal/crypto/hash/docs.go
@@ -4,8 +4,8 @@
 
 // Package blake2botp provides a BLAKE2b-based hash implementation for use with one-time passwords (OTP).
 //
-// The package defines a Blake2botp struct that wraps the BLAKE2b hash function from the golang.org/x/crypto/blake2b package.
-// It implements the hash.Hash interface, allowing it to be used as a drop-in replacement for other hash functions in OTP implementations.
+// The package defines a Blake2botp struct that wraps the BLAKE2b hash function from the [golang.org/x/crypto/blake2b] package.
+// It implements the [hash.Hash] interface, allowing it to be used as a drop-in replacement for other hash functions in OTP implementations.
 //
 // Usage:
 //
@@ -13,7 +13,7 @@
 //	// Use the hasher with the OTP implementation
 //
 // The package provides a New512 function that returns a new instance of the Blake2botp hash with a 512-bit output size.
-// The returned hash implements the hash.Hash interface, so it can be used directly with OTP libraries that expect a hash function.
+// The returned hash implements the [hash.Hash] interface, so it can be used directly with OTP libraries that expect a hash function.
 //
 // Note: The Blake2botp hash is based on the BLAKE2b hash function, which provides a secure and efficient hashing algorithm.
 // However, it's important to ensure that the secret key used with the OTP implementation is kept secure and not disclosed to unauthorized parties.


### PR DESCRIPTION
- [+] docs(hash): update documentation to use Go doc links for hash.Hash interface
- [+] docs(hash): update documentation to use Go doc link for golang.org/x/crypto/blake2b package
- [+] docs(hash): update documentation comments to use Go doc links for hash.Hash interface