### PR TITLE
Implement [Internal] [Cryptography] [Hash Function] Blake2b variants

### DIFF
--- a/internal/crypto/hash/blake2b.go
+++ b/internal/crypto/hash/blake2b.go
@@ -10,6 +10,24 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+// New256 returns a new instance of the Blake2botp hash with a 256-bit output size.
+// The returned hash implements the [hash.Hash] interface.
+func New256() hash.Hash {
+	h, _ := blake2b.New256(nil)
+	return &Blake2botp{
+		hash: h,
+	}
+}
+
+// New384 returns a new instance of the Blake2botp hash with a 384-bit output size.
+// The returned hash implements the [hash.Hash] interface.
+func New384() hash.Hash {
+	h, _ := blake2b.New384(nil)
+	return &Blake2botp{
+		hash: h,
+	}
+}
+
 // New512 returns a new instance of the Blake2botp hash with a 512-bit output size.
 // The returned hash implements the [hash.Hash] interface.
 func New512() hash.Hash {

--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -34,11 +34,23 @@ const (
 	// It offers the highest level of security among the commonly used SHA variants.
 	SHA512 = "SHA512"
 
-	// BLAKE2b represents the secure BLAKE2b hash function.
+	// BLAKE2b256 represents the secure BLAKE2b hash function with a 256-bit output size.
+	// It provides a 256-bit (32-byte) hash value.
+	//
+	// Note: Some 2FA Mobile Apps might not support this hash function, so it is recommended to build your own 2FA Mobile apps.
+	BLAKE2b256 = "BLAKE2b256"
+
+	// BLAKE2b384 represents the secure BLAKE2b hash function with a 384-bit output size.
+	// It provides a 384-bit (48-byte) hash value.
+	//
+	// Note: Some 2FA Mobile Apps might not support this hash function, so it is recommended to build your own 2FA Mobile apps.
+	BLAKE2b384 = "BLAKE2b384"
+
+	// BLAKE2b512 represents the secure BLAKE2b hash function with a 512-bit output size.
 	// It provides a 512-bit (64-byte) hash value.
 	//
 	// Note: Some 2FA Mobile Apps might not support this hash function, so it is recommended to build your own 2FA Mobile apps.
-	BLAKE2b = "BLAKE2b"
+	BLAKE2b512 = "BLAKE2b512"
 )
 
 // TimeSource is a function type that returns the current time.
@@ -67,7 +79,7 @@ var DefaultConfig = Config{
 	Period:       30,
 	UseSignature: false,
 	TimeSource:   time.Now,
-	Hasher:       &gotp.Hasher{HashName: BLAKE2b, Digest: blake2botp.New512},
+	Hasher:       &gotp.Hasher{HashName: BLAKE2b512, Digest: blake2botp.New512},
 }
 
 // TOTPVerifier is a TOTP verifier that implements the OTPVerifier interface.
@@ -191,8 +203,10 @@ func OTPFactory(config Config) OTPVerifier {
 
 // Hashers is a map of supported hash functions.
 var Hashers = map[string]*gotp.Hasher{
-	SHA1:    {HashName: SHA1, Digest: sha1.New},
-	SHA256:  {HashName: SHA256, Digest: sha256.New},
-	SHA512:  {HashName: SHA512, Digest: sha512.New},
-	BLAKE2b: {HashName: BLAKE2b, Digest: blake2botp.New512},
+	SHA1:       {HashName: SHA1, Digest: sha1.New},
+	SHA256:     {HashName: SHA256, Digest: sha256.New},
+	SHA512:     {HashName: SHA512, Digest: sha512.New},
+	BLAKE2b256: {HashName: BLAKE2b256, Digest: blake2botp.New256},
+	BLAKE2b384: {HashName: BLAKE2b384, Digest: blake2botp.New384},
+	BLAKE2b512: {HashName: BLAKE2b512, Digest: blake2botp.New512},
 }


### PR DESCRIPTION
- [+] feat(blake2b): add New256 and New384 functions for Blake2b hash with 256-bit and 384-bit output sizes
- [+] test(blake2botp): add tests for TOTP and HOTP using different Blake2b hash sizes
- [+] feat(otpverifier): add support for BLAKE2b256 and BLAKE2b384 hash functions
- [+] test(otpverifier): update tests to cover different hash functions including BLAKE2b256, BLAKE2b384, and BLAKE2b512
- [+] refactor(otpverifier): rename BLAKE2b to BLAKE2b512 for clarity