### PR TITLE
Reorganize Codebase

### DIFF
--- a/internal/otpverifier/deadcode.go
+++ b/internal/otpverifier/deadcode.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package otpverifier
+
+// SetCounter is a no-op for TOTPVerifier since TOTP doesn't use a counter.
+func (v *TOTPVerifier) SetCounter(counter uint64) {
+	// No-op for TOTP
+}
+
+// GetCounter always returns 0 for TOTPVerifier since TOTP doesn't use a counter.
+func (v *TOTPVerifier) GetCounter() uint64 {
+	return 0
+}

--- a/internal/otpverifier/hotp.go
+++ b/internal/otpverifier/hotp.go
@@ -90,13 +90,3 @@ func (v *HOTPVerifier) SetCounter(counter uint64) {
 func (v *HOTPVerifier) GetCounter() uint64 {
 	return v.config.Counter
 }
-
-// SetCounter is a no-op for TOTPVerifier since TOTP doesn't use a counter.
-func (v *TOTPVerifier) SetCounter(counter uint64) {
-	// No-op for TOTP
-}
-
-// GetCounter always returns 0 for TOTPVerifier since TOTP doesn't use a counter.
-func (v *TOTPVerifier) GetCounter() uint64 {
-	return 0
-}

--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -316,9 +316,12 @@ func TestHOTPVerifier_SaveQRCodeImage(t *testing.T) {
 
 func TestHOTPVerifier_VerifySyncWindow(t *testing.T) {
 	secret := gotp.RandomSecret(16)
-	// An arbitrarily chosen initial counter value
+	// Initialize the counter at an arbitrary value.
+	// Note: This situation simulates a scenario where a user's counter is significantly ahead,
+	// e.g., at 1337. If the user's counter is beyond the synchronization window,
+	// their tokens will not be verified, effectively rendering the tokens useless.
 	initialCounter := uint64(1337)
-	// The sync window allows verification of tokens that are ahead by 2
+	// The sync window defines how many tokens ahead of the last verified one can be accepted.
 	syncWindow := 2
 
 	hashFunctions := []string{


### PR DESCRIPTION
- [+] feat(otpverifier): move SetCounter and GetCounter methods for TOTPVerifier to deadcode.go
- [+] These methods are no-op for TOTPVerifier since TOTP doesn't use a counter. Moving them to a separate file named deadcode.go to indicate that they are not used and can be safely removed in the future.
- [+] test(otpverifier): add comments to TestHOTPVerifier_VerifySyncWindow test
- [+] Clarify the purpose of initializing the counter at an arbitrary value
- [+] Explain the scenario simulated by setting the counter significantly ahead
- [+] Describe the role of the sync window in token verification