### PR TITLE
Fix [URI Builder] QR Code That Can't Be Scanned

### DIFF
--- a/internal/otpverifier/hotp.go
+++ b/internal/otpverifier/hotp.go
@@ -28,6 +28,9 @@ func NewHOTPVerifier(config Config) *HOTPVerifier {
 	if config.Hasher == nil {
 		config.Hasher = DefaultConfig.Hasher
 	}
+	if config.URITemplate == "" {
+		config.URITemplate = DefaultConfig.URITemplate
+	}
 
 	hotp := gotp.NewHOTP(config.Secret, config.Digits, config.Hasher)
 	return &HOTPVerifier{

--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -166,6 +166,8 @@ func generateOTPURL(issuer, accountName string, config Config) string {
 	}
 
 	// Parse the URI template to get a base URL object.
+	// Note: It is important to use url.PathEscape for the issuer and account name
+	// because the URL won't work correctly without it when scanning the QR code.
 	baseURL, err := url.Parse(fmt.Sprintf(config.URITemplate, otpType, url.PathEscape(issuer), url.PathEscape(accountName)))
 	if err != nil {
 		panic(err)

--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -170,6 +170,7 @@ func generateOTPURL(issuer, accountName string, config Config) string {
 	// because the URL won't work correctly without it when scanning the QR code.
 	baseURL, err := url.Parse(fmt.Sprintf(config.URITemplate, otpType, url.PathEscape(issuer), url.PathEscape(accountName)))
 	if err != nil {
+		// Panic is better than handling the error using fmt, log, or any other method since this is an internal error.
 		panic(err)
 	}
 

--- a/internal/otpverifier/totp.go
+++ b/internal/otpverifier/totp.go
@@ -34,6 +34,9 @@ func NewTOTPVerifier(config Config) *TOTPVerifier {
 	if config.Hasher == nil {
 		config.Hasher = DefaultConfig.Hasher
 	}
+	if config.URITemplate == "" {
+		config.URITemplate = DefaultConfig.URITemplate
+	}
 
 	totp := gotp.NewTOTP(config.Secret, config.Digits, config.Period, config.Hasher)
 	return &TOTPVerifier{


### PR DESCRIPTION
- [+] refactor(otpverifier): improve URI template handling and URL generation
- [+] Add default URI template to HOTP and TOTP verifiers if not provided in config
- [+] Refactor `generateOTPURL` function to use `url.URL` for building the URL
- [+] Parse the URI template into a base URL object
- [+] Set query parameters using `url.Values`
- [+] Re-encode the query parameters and return the fully constructed URL string
- [+] Update the default URI template in `DefaultConfig` to remove the `counter` parameter
- [+] Remove the `strings` package import as it is no longer used

Note: This should work, even on mobile or other devices, for cryptographic purposes related to OTP.