### PR TITLE
Improve Initialize

### DIFF
--- a/internal/otpverifier/hotp.go
+++ b/internal/otpverifier/hotp.go
@@ -25,14 +25,9 @@ func NewHOTPVerifier(config Config) *HOTPVerifier {
 	if config.Digits == 0 {
 		config.Digits = DefaultConfig.Digits
 	}
-	if config.Hasher == nil {
+	if config.Hash != "" {
 		// If HashName is provided, use it to get the corresponding Hasher
-		if config.Hash != "" {
-			config.Hasher = config.GetHasherByName(config.Hash)
-		} else {
-			// Otherwise, use the default hasher
-			config.Hasher = DefaultConfig.Hasher
-		}
+		config.Hasher = config.GetHasherByName(config.Hash)
 	}
 	if config.URITemplate == "" {
 		config.URITemplate = DefaultConfig.URITemplate

--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -104,7 +104,6 @@ var DefaultConfig = Config{
 	Period:       30,
 	UseSignature: false,
 	TimeSource:   time.Now,
-	Hasher:       &gotp.Hasher{HashName: BLAKE2b512, Digest: blake2botp.New512},
 	SyncWindow:   1,
 	URITemplate:  "otpauth://%s/%s:%s?secret=%s&issuer=%s&digits=%d&algorithm=%s",
 }
@@ -214,6 +213,7 @@ func OTPFactory(config Config) OTPVerifier {
 }
 
 // GetHasherByName returns a pointer to a gotp.Hasher based on the given hash function name.
+// It panics if the hash function name is not supported or if the hash function name is empty.
 func (v *Config) GetHasherByName(Hash string) *gotp.Hasher {
 	hasher, exists := Hashers[Hash]
 	if !exists {

--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -206,6 +206,7 @@ func TestTOTPVerifier_BuildQRCode(t *testing.T) {
 	secret := gotp.RandomSecret(16)
 	config := otpverifier.Config{
 		Secret: secret,
+		Hash:   otpverifier.BLAKE2b512,
 	}
 	verifier := otpverifier.NewTOTPVerifier(config)
 
@@ -214,12 +215,11 @@ func TestTOTPVerifier_BuildQRCode(t *testing.T) {
 
 	// Create a custom QR code configuration
 	qrCodeConfig := otpverifier.QRCodeConfig{
-		Level:           qrcode.Medium,
-		Size:            256,
-		DisableBorder:   true,
-		TopText:         "Scan Me",
-		BottomText:      "OTP QR Code",
-		ForegroundColor: color.Black,
+		Level:         qrcode.Medium,
+		Size:          256,
+		DisableBorder: true,
+		TopText:       "Scan Me",
+		BottomText:    "OTP QR Code",
 	}
 
 	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName, qrCodeConfig)
@@ -242,6 +242,7 @@ func TestTOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	secret := gotp.RandomSecret(16)
 	config := otpverifier.Config{
 		Secret: secret,
+		Hash:   otpverifier.BLAKE2b512,
 	}
 	verifier := otpverifier.NewTOTPVerifier(config)
 
@@ -267,6 +268,7 @@ func TestHOTPVerifier_BuildQRCode(t *testing.T) {
 	config := otpverifier.Config{
 		Secret:  secret,
 		Counter: 1337,
+		Hash:    otpverifier.BLAKE2b512,
 	}
 	verifier := otpverifier.NewHOTPVerifier(config)
 
@@ -304,6 +306,7 @@ func TestHOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	config := otpverifier.Config{
 		Secret:  secret,
 		Counter: 1337,
+		Hash:    otpverifier.BLAKE2b512,
 	}
 	verifier := otpverifier.NewHOTPVerifier(config)
 

--- a/internal/otpverifier/totp.go
+++ b/internal/otpverifier/totp.go
@@ -31,14 +31,9 @@ func NewTOTPVerifier(config Config) *TOTPVerifier {
 	if config.TimeSource == nil {
 		config.TimeSource = DefaultConfig.TimeSource
 	}
-	if config.Hasher == nil {
+	if config.Hash != "" {
 		// If HashName is provided, use it to get the corresponding Hasher
-		if config.Hash != "" {
-			config.Hasher = config.GetHasherByName(config.Hash)
-		} else {
-			// Otherwise, use the default hasher
-			config.Hasher = DefaultConfig.Hasher
-		}
+		config.Hasher = config.GetHasherByName(config.Hash)
 	}
 	if config.URITemplate == "" {
 		config.URITemplate = DefaultConfig.URITemplate
@@ -52,6 +47,9 @@ func NewTOTPVerifier(config Config) *TOTPVerifier {
 }
 
 // Verify checks if the provided token and signature are valid for the current time.
+//
+// Note: This TOTP verification using [crypto/subtle] requires careful consideration
+// when setting TimeSource and Period to ensure correct usage.
 func (v *TOTPVerifier) Verify(token, signature string) bool {
 	generatedToken := v.totp.Now()
 	if v.config.UseSignature {


### PR DESCRIPTION
- [+] feat(otpverifier): remove default hasher from DefaultConfig
- [+] The default hasher is no longer set in the DefaultConfig. It is expected to be provided explicitly when creating a new OTPVerifier.

- [+] refactor(otpverifier): simplify hasher initialization in NewHOTPVerifier and NewTOTPVerifier
- [+] The hasher initialization logic in NewHOTPVerifier and NewTOTPVerifier has been simplified. If the Hash field is provided in the config, it is used to get the corresponding hasher using GetHasherByName. The default hasher is no longer used.

- [+] docs(otpverifier): add panic behavior documentation for GetHasherByName
- [+] The documentation for GetHasherByName now mentions that it panics if the provided hash function name is not supported or if it is empty.

- [+] test(otpverifier): update tests to provide explicit hash in config
- [+] The tests for BuildQRCode and SaveQRCodeImage have been updated to provide an explicit hash in the config when creating the OTPVerifier instances.

- [+] docs(otpverifier): add note about careful consideration when using TOTP verification
- [+] A note has been added to the documentation of the Verify method in TOTPVerifier, mentioning that careful consideration is required when setting TimeSource and Period to ensure correct usage of the TOTP verification using crypto/subtle.