### PR TITLE
Fix Comment on test

### DIFF
--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -645,7 +645,7 @@ func TestTOTPVerifier_VerifyPanic(t *testing.T) {
 func TestHOTPVerifier_VerifyPanic(t *testing.T) {
 	secret := gotp.RandomSecret(16)
 
-	// Create a TOTPVerifier with a negative sync window
+	// Create a HOTPVerifier with a negative sync window
 	config := otpverifier.Config{
 		Secret:     secret,
 		SyncWindow: -1,


### PR DESCRIPTION
- [+] test(otpverifier): fix comment in TestHOTPVerifier_VerifyPanic to refer to HOTPVerifier instead of TOTPVerifier