### PR TITLE
Implement CustomURITemplateParams for QR Code Builder

### DIFF
--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -98,16 +98,17 @@ type OTPVerifier interface {
 
 // Config is a struct that holds the configuration options for the OTP verifier.
 type Config struct {
-	Secret       string
-	Digits       int
-	Period       int
-	UseSignature bool
-	TimeSource   TimeSource
-	Counter      uint64
-	Hasher       *gotp.Hasher
-	SyncWindow   int
-	URITemplate  string
-	Hash         string
+	Secret                  string
+	Digits                  int
+	Period                  int
+	UseSignature            bool
+	TimeSource              TimeSource
+	Counter                 uint64
+	Hasher                  *gotp.Hasher
+	SyncWindow              int
+	URITemplate             string
+	CustomURITemplateParams map[string]string
+	Hash                    string
 }
 
 // QRCodeConfig represents the configuration for generating QR codes.
@@ -126,12 +127,13 @@ type QRCodeConfig struct {
 
 // DefaultConfig represents the default configuration values.
 var DefaultConfig = Config{
-	Digits:       6,
-	Period:       30,
-	UseSignature: false,
-	TimeSource:   time.Now,
-	SyncWindow:   1,
-	URITemplate:  "otpauth://%s/%s:%s?secret=%s&issuer=%s&digits=%d&algorithm=%s",
+	Digits:                  6,
+	Period:                  30,
+	UseSignature:            false,
+	TimeSource:              time.Now,
+	SyncWindow:              1,
+	URITemplate:             "otpauth://%s/%s:%s?secret=%s&issuer=%s&digits=%d&algorithm=%s",
+	CustomURITemplateParams: nil,
 }
 
 // Hashers is a map of supported hash functions.
@@ -230,6 +232,15 @@ func (v *Config) generateOTPURL(issuer, accountName string) string {
 	}
 	if otpType != gotp.OtpTypeHotp {
 		query.Set("period", fmt.Sprint(v.Period))
+	}
+
+	// Add custom URI Template parameters to the query if CustomURITemplateParams is not nil
+	if v.CustomURITemplateParams != nil {
+		for key, value := range v.CustomURITemplateParams {
+			escapedKey := url.PathEscape(key)
+			escapedValue := url.PathEscape(value)
+			query.Set(escapedKey, escapedValue)
+		}
 	}
 
 	// Re-encode the query parameters.

--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -314,6 +314,45 @@ func TestTOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	}
 }
 
+func TestTOTPVerifier_BuildQRCodeWithCustomParams(t *testing.T) {
+	secret := gotp.RandomSecret(16)
+	config := otpverifier.Config{
+		Secret: secret,
+		Hash:   otpverifier.BLAKE2b512,
+		CustomURITemplateParams: map[string]string{
+			"foo": "bar",
+		},
+	}
+	verifier := otpverifier.NewTOTPVerifier(config)
+
+	issuer := "TestIssuer"
+	accountName := "TestAccount"
+
+	// Create a custom QR code configuration
+	qrCodeConfig := otpverifier.QRCodeConfig{
+		Level:         qrcode.Medium,
+		Size:          256,
+		DisableBorder: true,
+		TopText:       "Scan Me",
+		BottomText:    "OTP QR Code",
+	}
+
+	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName, qrCodeConfig)
+	if err != nil {
+		t.Errorf("Failed to build QR code: %v", err)
+	}
+
+	if len(qrCodeBytes) == 0 {
+		t.Errorf("QR code bytes should not be empty")
+	}
+
+	// Try decoding the QR code bytes as a PNG image
+	_, err = png.Decode(bytes.NewReader(qrCodeBytes))
+	if err != nil {
+		t.Errorf("Failed to decode QR code as PNG: %v", err)
+	}
+}
+
 func TestHOTPVerifier_BuildQRCode(t *testing.T) {
 	secret := gotp.RandomSecret(16)
 	config := otpverifier.Config{
@@ -375,6 +414,47 @@ func TestHOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	_, err = os.Stat(filename)
 	if os.IsNotExist(err) {
 		t.Errorf("QR code image file was not created")
+	}
+}
+
+func TestHOTPVerifier_BuildQRCodeWithCustomParams(t *testing.T) {
+	secret := gotp.RandomSecret(16)
+	config := otpverifier.Config{
+		Secret:  secret,
+		Counter: 1337,
+		Hash:    otpverifier.BLAKE2b512,
+		CustomURITemplateParams: map[string]string{
+			"foo": "bar",
+		},
+	}
+	verifier := otpverifier.NewHOTPVerifier(config)
+
+	issuer := "TestIssuer"
+	accountName := "TestAccount"
+
+	// Create a custom QR code configuration
+	qrCodeConfig := otpverifier.QRCodeConfig{
+		Level:           qrcode.Medium,
+		Size:            256,
+		DisableBorder:   true,
+		TopText:         "Scan Me",
+		BottomText:      "OTP QR Code",
+		ForegroundColor: color.Black,
+	}
+
+	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName, qrCodeConfig)
+	if err != nil {
+		t.Errorf("Failed to build QR code: %v", err)
+	}
+
+	if len(qrCodeBytes) == 0 {
+		t.Errorf("QR code bytes should not be empty")
+	}
+
+	// Try decoding the QR code bytes as a PNG image
+	_, err = png.Decode(bytes.NewReader(qrCodeBytes))
+	if err != nil {
+		t.Errorf("Failed to decode QR code as PNG: %v", err)
 	}
 }
 


### PR DESCRIPTION
- [+] feat(otpverifier): add support for custom URI template parameters in OTP configuration
- [+] add `CustomURITemplateParams` field to `Config` struct to allow specifying custom parameters for the OTP URI template
- [+] update `generateOTPURL` method to include custom URI template parameters in the generated URL if `CustomURITemplateParams` is not nil
- [+] add unit tests `TestTOTPVerifier_BuildQRCodeWithCustomParams` and `TestHOTPVerifier_BuildQRCodeWithCustomParams` to verify the functionality of building QR codes with custom URI template parameters