### PR TITLE
Improve HOTP sync window

### DIFF
--- a/internal/otpverifier/benchmark_test.go
+++ b/internal/otpverifier/benchmark_test.go
@@ -88,7 +88,7 @@ func BenchmarkHOTPVerify(b *testing.B) {
 		b.Run(hashFunc, func(b *testing.B) {
 			config := otpverifier.Config{
 				Secret:     secret,
-				SyncWindow: 2,
+				SyncWindow: 1,
 				Hash:       hashFunc,
 			}
 			verifier := otpverifier.NewHOTPVerifier(config)
@@ -105,7 +105,7 @@ func BenchmarkHOTPVerify(b *testing.B) {
 			config := otpverifier.Config{
 				Secret:       secret,
 				Hash:         hashFunc,
-				SyncWindow:   2,
+				SyncWindow:   1,
 				UseSignature: true,
 			}
 			verifier := otpverifier.NewHOTPVerifier(config)

--- a/internal/otpverifier/benchmark_test.go
+++ b/internal/otpverifier/benchmark_test.go
@@ -88,7 +88,7 @@ func BenchmarkHOTPVerify(b *testing.B) {
 		b.Run(hashFunc, func(b *testing.B) {
 			config := otpverifier.Config{
 				Secret:     secret,
-				SyncWindow: 1,
+				SyncWindow: 2,
 				Hash:       hashFunc,
 			}
 			verifier := otpverifier.NewHOTPVerifier(config)
@@ -105,7 +105,7 @@ func BenchmarkHOTPVerify(b *testing.B) {
 			config := otpverifier.Config{
 				Secret:       secret,
 				Hash:         hashFunc,
-				SyncWindow:   1,
+				SyncWindow:   2,
 				UseSignature: true,
 			}
 			verifier := otpverifier.NewHOTPVerifier(config)

--- a/internal/otpverifier/hotp.go
+++ b/internal/otpverifier/hotp.go
@@ -70,7 +70,7 @@ func (v *HOTPVerifier) Verify(token, signature string) bool {
 
 	// Check if sync window is applied
 	// Note: Understanding this sync window requires skilled mathematical reasoning.
-	if v.config.SyncWindow > 1 {
+	if v.config.SyncWindow > 0 {
 		for i := 0; i <= v.config.SyncWindow; i++ {
 			expectedCounter := int(v.config.Counter) + i
 			generatedToken := v.Hotp.At(expectedCounter)

--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -618,7 +618,7 @@ func TestHOTPVerifier_VerifySyncWindow(t *testing.T) {
 	// their tokens will not be verified, effectively rendering the tokens useless.
 	initialCounter := uint64(1337)
 	// The sync window defines how many tokens ahead of the last verified one can be accepted.
-	syncWindow := 2
+	syncWindow := 1
 
 	hashFunctions := []string{
 		otpverifier.SHA1,
@@ -667,7 +667,7 @@ func TestHOTPVerifier_VerifySyncWindow(t *testing.T) {
 		}
 
 		// Generate a token for a counter value outside the sync window
-		outsideWindowToken := verifier.Hotp.At(int(initialCounter) + syncWindow + 4)
+		outsideWindowToken := verifier.Hotp.At(int(initialCounter) + syncWindow + 3)
 
 		// Verify this token should fail
 		if verifier.Verify(outsideWindowToken, "") {
@@ -684,7 +684,7 @@ func TestHOTPVerifier_VerifySyncWindowWithSignature(t *testing.T) {
 	// their tokens will not be verified, effectively rendering the tokens useless.
 	initialCounter := uint64(1337)
 	// The sync window defines how many tokens ahead of the last verified one can be accepted.
-	syncWindow := 2
+	syncWindow := 1
 	useSignature := true
 
 	hashFunctions := []string{
@@ -745,7 +745,7 @@ func TestHOTPVerifier_VerifySyncWindowWithSignature(t *testing.T) {
 		}
 
 		// Generate a token and signature for a counter value outside the sync window
-		outsideWindowToken := verifier.Hotp.At(int(initialCounter) + syncWindow + 4)
+		outsideWindowToken := verifier.Hotp.At(int(initialCounter) + syncWindow + 3)
 		outsideWindowSignature := generateSignature(outsideWindowToken)
 
 		// Verify this token and signature should fail
@@ -759,7 +759,7 @@ func TestHOTPVerifier_ResetSyncWindow(t *testing.T) {
 	secret := gotp.RandomSecret(16)
 	initialCounter := uint64(1337)
 	initialSyncWindow := 2
-	resetSyncWindow := 1 // The new sync window value after reset
+	resetSyncWindow := 0 // The new sync window value after reset
 
 	verifier := otpverifier.NewHOTPVerifier(otpverifier.Config{
 		Secret:     secret,
@@ -796,7 +796,7 @@ func TestHOTPVerifier_ResetSyncWindow(t *testing.T) {
 func TestHOTPVerifier_ResetSyncWindowToDefault(t *testing.T) {
 	secret := gotp.RandomSecret(16)
 	initialCounter := uint64(1337)
-	initialSyncWindow := 2
+	initialSyncWindow := 1
 	verifier := otpverifier.NewHOTPVerifier(otpverifier.Config{
 		Secret:     secret,
 		Counter:    initialCounter,


### PR DESCRIPTION
- [+] test(benchmark_test.go): increase sync window from 1 to 2 in BenchmarkHOTPVerify
- [+] test(hotp.go): change sync window check from > 1 to > 0
- [+] test(otpverifier_test.go): decrease sync window from 2 to 1 in TestHOTPVerifier_VerifySyncWindow
- [+] test(otpverifier_test.go): decrease sync window from 2 to 1 in TestHOTPVerifier_VerifySyncWindowWithSignature
- [+] test(otpverifier_test.go): generate token for counter value 3 steps ahead instead of 4 in TestHOTPVerifier_VerifySyncWindow and TestHOTPVerifier_VerifySyncWindowWithSignature
- [+] test(otpverifier_test.go): change reset sync window from 1 to 0 in TestHOTPVerifier_ResetSyncWindow
- [+] test(otpverifier_test.go): decrease initial sync window from 2 to 1 in TestHOTPVerifier_ResetSyncWindowToDefault