### PR TITLE
Rename JSON Tags

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -28,13 +28,13 @@ type InfoManager interface {
 
 // Info represents the 2FA information stored for a user.
 type Info struct {
-	ContextKey     string    `json:"context_key"`
+	ContextKey     string    `json:"contextkey"`
 	Secret         string    `json:"secret"`
-	CookieValue    string    `json:"cookie_value"`
-	ExpirationTime time.Time `json:"expiration_time"`
+	CookieValue    string    `json:"cookie"`
+	ExpirationTime time.Time `json:"expiration"`
 	Registered     bool      `json:"registered"`
 	Identifier     string    `json:"identifier"`
-	QRCodeData     []byte    `json:"qr_code_data"`
+	QRCodeData     []byte    `json:"qrcodedata"`
 }
 
 // NewInfo creates a new empty Info struct based on the provided Config.


### PR DESCRIPTION
- [+] refactor(storage.go): rename json tags for Info struct fields
- [+] Rename `context_key` to `contextkey`
- [+] Rename `cookie_value` to `cookie`
- [+] Rename `expiration_time` to `expiration`
- [+] Rename `qr_code_data` to `qrcodedata`

Note: This renaming is done to avoid confusion because the Info struct is used by the Fiber 2FA middleware and stored in a separate database.  Since The Fiber 2FA middleware requires an independent storage to maintain the 2FA-related data, which is why it uses c.Locals to allow set values from another database (e.g., the main database) for the 2FA functionality.