### PR TITLE
Improve [Storage] Info 2FA Manager

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -28,13 +28,13 @@ type InfoManager interface {
 
 // Info represents the 2FA information stored for a user.
 type Info struct {
-	ContextKey     string    `json:"contextkey"`
+	ContextKey     string    `json:"contextkey,omitempty"`
 	Secret         string    `json:"secret"`
-	CookieValue    string    `json:"cookie"`
-	ExpirationTime time.Time `json:"expiration"`
+	CookieValue    string    `json:"cookie,omitempty"`
+	ExpirationTime time.Time `json:"expiration,omitempty"`
 	Registered     bool      `json:"registered"`
-	Identifier     string    `json:"identifier"`
-	QRCodeData     []byte    `json:"qrcodedata"`
+	Identifier     string    `json:"identifier,omitempty"`
+	QRCodeData     []byte    `json:"qrcodedata,omitempty"`
 }
 
 // NewInfo creates a new empty Info struct based on the provided Config.


### PR DESCRIPTION
- [+] refactor(storage.go): make several Info struct fields optional in JSON serialization
- [+] The `omitempty` JSON tag option is added to the `ContextKey`, `CookieValue`, `ExpirationTime`, `Identifier`, and `QRCodeData` fields of the `Info` struct. This allows omitting these fields from the JSON representation when their values are empty or zero.