### PR TITLE
Fix HOTP DefaultConfig

### DIFF
--- a/internal/otpverifier/hotp.go
+++ b/internal/otpverifier/hotp.go
@@ -78,7 +78,11 @@ func NewHOTPVerifier(config ...Config) *HOTPVerifier {
 		// There is no limit until the client or server stops. If neither
 		// of them stops, it keeps rolling the counter for the sake of crypto 🎰
 		recentCounters = ring.New(recentCountersSize)
-		c.ResyncWindowDelay = DefaultConfig.ResyncWindowDelay
+
+		// This should be correct.
+		if c.ResyncWindowDelay == 0 {
+			c.ResyncWindowDelay = DefaultConfig.ResyncWindowDelay
+		}
 
 	}
 


### PR DESCRIPTION
- [+] fix(hotp.go): set ResyncWindowDelay to default value only if it is zero