### PR TITLE
[TOTP] Bound SyncWindow to TimeSource as Default Config

### DIFF
--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -179,11 +179,10 @@ func TestTOTPVerifier_PeriodicCleanup(t *testing.T) {
 	secret := gotp.RandomSecret(16)
 	period := 10 // Set the token validity period to 10 seconds
 	config := otpverifier.Config{
-		Secret:     secret,
-		Period:     period,
-		SyncWindow: 1,
-		Digits:     6,
-		Hash:       otpverifier.SHA256,
+		Secret: secret,
+		Period: period,
+		Digits: 6,
+		Hash:   otpverifier.SHA256,
 	}
 
 	verifier := otpverifier.NewTOTPVerifier(config)


### PR DESCRIPTION
- [+] test(otpverifier): remove SyncWindow from TOTPVerifier config in PeriodicCleanup test
- [+] refactor(otpverifier): bound SyncWindow to TimeSource in TOTPVerifier constructor
- [+] docs(otpverifier): add note explaining the reasoning behind bounding SyncWindow to TimeSource