### PR TITLE
Improve [TOTP] Goroutine

### DIFF
--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -202,8 +202,14 @@ func TestTOTPVerifier_PeriodicCleanup(t *testing.T) {
 	verifier.Verify(token2)
 
 	// Verify expired tokens are removed
-	if len(verifier.UsedTokens) != 1 {
-		t.Errorf("Expected 1 used token after periodic cleanup, but got %d", len(verifier.UsedTokens))
+	var usedTokensCount int
+	verifier.UsedTokens.Range(func(key, value any) bool {
+		usedTokensCount++
+		return true
+	})
+
+	if usedTokensCount != 1 {
+		t.Errorf("Expected 1 used token after periodic cleanup, but got %d", usedTokensCount)
 	}
 }
 


### PR DESCRIPTION
- [+] refactor(otpverifier): replace UsedTokens map with sync.Map for concurrency safety
- [+] test(otpverifier): update TestTOTPVerifier_PeriodicCleanup to use sync.Map for counting used tokens
- [+] refactor(otpverifier): remove unnecessary mutex locks when accessing UsedTokens sync.Map
- [+] refactor(otpverifier): simplify startPeriodicCleanup by removing unnecessary length check
- [+] refactor(otpverifier): use sync.Map's Range method in CleanUpExpiredTokens for iterating over used tokens