### PR TITLE
Remove mutex lock

### DIFF
--- a/internal/otpverifier/totp.go
+++ b/internal/otpverifier/totp.go
@@ -165,9 +165,7 @@ func (v *TOTPVerifier) verifyWithSignature(token, signature string) bool {
 				}
 			}
 
-			v.m.Lock()
 			v.UsedTokens.Store(expectedTimeStep, token) // Record the token as used
-			v.m.Unlock()
 			return true
 		}
 	}


### PR DESCRIPTION
- [+] refactor(totp.go): remove unnecessary mutex lock and unlock when storing used tokens

Note: This doesn't matter anyway since it unused