### PR TITLE
Improve [TOTP Default Config] Default Time

### DIFF
--- a/config.go
+++ b/config.go
@@ -221,7 +221,7 @@ var DefaultConfig = Config{
 	DigitsCount:          otp.DefaultConfig.Digits,
 	Period:               otp.DefaultConfig.Period,
 	Hash:                 otp.SHA512,
-	TimeSource:           otp.DefaultConfig.DefaultTime().UTC,
+	TimeSource:           otp.DefaultConfig.TOTPTime().UTC,
 	SyncWindow:           otp.DefaultConfig.SyncWindow,
 	SkipCookies:          nil,
 	CookieName:           "twofa_cookie",

--- a/config.go
+++ b/config.go
@@ -221,7 +221,7 @@ var DefaultConfig = Config{
 	DigitsCount:          otp.DefaultConfig.Digits,
 	Period:               otp.DefaultConfig.Period,
 	Hash:                 otp.SHA512,
-	TimeSource:           otp.DefaultConfig.TimeSource,
+	TimeSource:           otp.DefaultConfig.DefaultTime().UTC,
 	SyncWindow:           otp.DefaultConfig.SyncWindow,
 	SkipCookies:          nil,
 	CookieName:           "twofa_cookie",

--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -395,11 +395,11 @@ func (v *Config) cryptopowpow10(exponent int) uint64 {
 	return result
 }
 
-// DefaultTime returns the current time in the https://en.wikipedia.org/wiki/South_Pole time zone.
+// TOTPTime returns the current time in the https://en.wikipedia.org/wiki/South_Pole time zone.
 // It is used as the default time source for TOTP if no custom time source is provided and the sync window is set to -1.
 //
 // Note: The returned time is always expressed in UTC (Coordinated Universal Time) to avoid any ambiguity caused by local time zone offsets.
-func (v *Config) DefaultTime() time.Time {
+func (v *Config) TOTPTime() time.Time {
 	location, _ := time.LoadLocation("Antarctica/South_Pole")
 	return time.Now().In(location)
 }

--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -207,7 +207,6 @@ var DefaultConfig = Config{
 	Digits:                  6,
 	Period:                  30,
 	UseSignature:            false,
-	TimeSource:              time.Now,
 	SyncWindow:              HighStrict,
 	ResyncWindowDelay:       30 * time.Minute,
 	CounterMismatch:         CounterMismatchThreshold3x,
@@ -394,4 +393,13 @@ func (v *Config) cryptopowpow10(exponent int) uint64 {
 		result *= 10
 	}
 	return result
+}
+
+// DefaultTime returns the current time in the https://en.wikipedia.org/wiki/South_Pole time zone.
+// It is used as the default time source for TOTP if no custom time source is provided and the sync window is set to -1.
+//
+// Note: The returned time is always expressed in UTC (Coordinated Universal Time) to avoid any ambiguity caused by local time zone offsets.
+func (v *Config) DefaultTime() time.Time {
+	location, _ := time.LoadLocation("Antarctica/South_Pole")
+	return time.Now().In(location)
 }

--- a/internal/otpverifier/totp.go
+++ b/internal/otpverifier/totp.go
@@ -49,7 +49,7 @@ func NewTOTPVerifier(config ...Config) *TOTPVerifier {
 	// The RFC 6238 (TOTP specification) does not define a specific synchronization window, but it is a common practice to implement it in TOTP systems to accommodate
 	// for real-world scenarios where perfect clock synchronization is not always possible (e.g, traveling (in airplane), living in antartica, ISS-NASA).
 	if c.TimeSource == nil && c.SyncWindow != 0 {
-		c.TimeSource = DefaultConfig.DefaultTime().UTC
+		c.TimeSource = DefaultConfig.TOTPTime().UTC
 		c.SyncWindow = DefaultConfig.SyncWindow
 	}
 

--- a/internal/otpverifier/totp.go
+++ b/internal/otpverifier/totp.go
@@ -49,7 +49,7 @@ func NewTOTPVerifier(config ...Config) *TOTPVerifier {
 	// The RFC 6238 (TOTP specification) does not define a specific synchronization window, but it is a common practice to implement it in TOTP systems to accommodate
 	// for real-world scenarios where perfect clock synchronization is not always possible (e.g, traveling (in airplane), living in antartica, ISS-NASA).
 	if c.TimeSource == nil && c.SyncWindow != 0 {
-		c.TimeSource = DefaultConfig.TimeSource
+		c.TimeSource = DefaultConfig.DefaultTime().UTC
 		c.SyncWindow = DefaultConfig.SyncWindow
 	}
 


### PR DESCRIPTION
- [+] refactor(config): change default TimeSource to UTC time in South Pole timezone
- [+] refactor(otpverifier): remove TimeSource from DefaultConfig
- [+] feat(otpverifier): add DefaultTime method to Config to return current time in South Pole timezone
- [+] refactor(totp): use DefaultTime from Config as default TimeSource if nil and SyncWindow is -1