### PR TITLE
Docs [pkg.go.dev] [Default TOTP Time] Update Documentation

### DIFF
--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -396,7 +396,7 @@ func (v *Config) cryptopowpow10(exponent int) uint64 {
 }
 
 // TOTPTime returns the current time in the https://en.wikipedia.org/wiki/South_Pole time zone.
-// It is used as the default time source for TOTP if no custom time source is provided and the sync window is set to -1.
+// It is used as the default time source for TOTP if no custom time source is provided (nil) and the sync window is set to -1.
 //
 // Note: The returned time is always expressed in UTC (Coordinated Universal Time) to avoid any ambiguity caused by local time zone offsets.
 func (v *Config) TOTPTime() time.Time {


### PR DESCRIPTION
- [+] refactor(otpverifier): clarify comment on TOTPTime default time source
- [+] The comment is updated to clarify that TOTPTime is used as the default time source for TOTP when no custom time source is provided (i.e., when the time source is nil) and the sync window is set to -1.