### PR TITLE
Improve [Helper Function] [Hash] Documentation & Explicit Panic (Crash)

### DIFF
--- a/internal/otpverifier/otpverifier.go
+++ b/internal/otpverifier/otpverifier.go
@@ -332,12 +332,33 @@ func OTPFactory(config Config) OTPVerifier {
 	return NewTOTPVerifier(config)
 }
 
-// GetHasherByName returns a pointer to a gotp.Hasher based on the given hash function name.
-// It panics if the hash function name is not supported or if the hash function name is empty.
+// GetHasherByName returns a pointer to a [gotp.Hasher] based on the given hash function name.
+// It panics if the hash function name is empty or not supported.
+//
+// The supported hash function names are:
+//   - [SHA1]
+//   - [SHA224]
+//   - [SHA256]
+//   - [SHA384]
+//   - [SHA512]
+//   - [SHA512S224]
+//   - [SHA512S256]
+//   - [BLAKE2b256]
+//   - [BLAKE2b384]
+//   - [BLAKE2b512]
+//   - [BLAKE3256]
+//   - [BLAKE3384]
+//   - [BLAKE3512]
+//
+// Note: The hash function name is case-sensitive.
 func (v *Config) GetHasherByName(Hash string) *gotp.Hasher {
+	if Hash == "" {
+		panic("GetHasherByName: hash function name cannot be empty")
+	}
+
 	hasher, exists := Hashers[Hash]
 	if !exists {
-		panic(fmt.Sprintf("Hash function %s is not supported", Hash))
+		panic(fmt.Sprintf("GetHasherByName: hash function %s is not supported", Hash))
 	}
 	return hasher
 }

--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -1271,13 +1271,28 @@ func TestGetHasherByName(t *testing.T) {
 			if r := recover(); r == nil {
 				t.Errorf("GetHasherByName() did not panic with unsupported hash function")
 			} else {
-				expected := "Hash function NotAHash is not supported"
+				expected := "GetHasherByName: hash function NotAHash is not supported"
 				if r != expected {
 					t.Errorf("GetHasherByName() panic = %v, want %v", r, expected)
 				}
 			}
 		}()
 		config.GetHasherByName("NotAHash")
+	})
+
+	// Test case for empty hash function name
+	t.Run("EmptyHash", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("GetHasherByName() did not panic with empty hash function name")
+			} else {
+				expected := "GetHasherByName: hash function name cannot be empty"
+				if r != expected {
+					t.Errorf("GetHasherByName() panic = %v, want %v", r, expected)
+				}
+			}
+		}()
+		config.GetHasherByName("")
 	})
 }
 


### PR DESCRIPTION
- [+] feat(otpverifier): add support for multiple hash functions in GetHasherByName
- [+] The GetHasherByName method now supports the following hash functions:
- [+] SHA1
- [+] SHA224
- [+] SHA256
- [+] SHA384
- [+] SHA512
- [+] SHA512S224
- [+] SHA512S256
- [+] BLAKE2b256
- [+] BLAKE2b384
- [+] BLAKE2b512
- [+] BLAKE3256
- [+] BLAKE3384
- [+] BLAKE3512

- [+] refactor(otpverifier): improve error handling in GetHasherByName
- [+] Panic with a more descriptive error message when the hash function is not supported
- [+] Panic when the hash function name is empty

- [+] test(otpverifier): add test case for empty hash function name in GetHasherByName