### PR TITLE
Add more Hash Function for Testing

### DIFF
--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -120,6 +120,9 @@ func TestDefaultConfigTOTPVerifier_Verify(t *testing.T) {
 		otpverifier.BLAKE2b256,
 		otpverifier.BLAKE2b384,
 		otpverifier.BLAKE2b512,
+		otpverifier.BLAKE3256,
+		otpverifier.BLAKE3384,
+		otpverifier.BLAKE3512,
 	}
 
 	for _, hashFunc := range hashFunctions {
@@ -1122,10 +1125,18 @@ func TestHOTPVerifier_VerifySyncWindowMediumStrict(t *testing.T) {
 
 	hashFunctions := []string{
 		otpverifier.SHA1,
+		otpverifier.SHA224,
 		otpverifier.SHA256,
+		otpverifier.SHA384,
 		otpverifier.SHA512,
+		otpverifier.SHA512S224,
+		otpverifier.SHA512S256,
 		otpverifier.BLAKE2b256,
+		otpverifier.BLAKE2b384,
+		otpverifier.BLAKE2b512,
 		otpverifier.BLAKE3256,
+		otpverifier.BLAKE3384,
+		otpverifier.BLAKE3512,
 	}
 
 	for _, hashFunc := range hashFunctions {
@@ -1181,10 +1192,18 @@ func TestHOTPVerifier_VerifySyncWindowLowStrict(t *testing.T) {
 
 	hashFunctions := []string{
 		otpverifier.SHA1,
+		otpverifier.SHA224,
 		otpverifier.SHA256,
+		otpverifier.SHA384,
 		otpverifier.SHA512,
+		otpverifier.SHA512S224,
+		otpverifier.SHA512S256,
 		otpverifier.BLAKE2b256,
+		otpverifier.BLAKE2b384,
+		otpverifier.BLAKE2b512,
 		otpverifier.BLAKE3256,
+		otpverifier.BLAKE3384,
+		otpverifier.BLAKE3512,
 	}
 
 	for _, hashFunc := range hashFunctions {


### PR DESCRIPTION
- [+] test(otpverifier): add more hash functions to test cases
- [+] Add BLAKE3 hash functions (BLAKE3256, BLAKE3384, BLAKE3512) to TestDefaultConfigTOTPVerifier_Verify
- [+] Add additional hash functions (SHA224, SHA384, SHA512S224, SHA512S256, BLAKE2b384, BLAKE2b512, BLAKE3384, BLAKE3512) to TestHOTPVerifier_VerifySyncWindowMediumStrict and TestHOTPVerifier_VerifySyncWindowLowStrict test cases to improve test coverage