### PR TITLE
Reorganize [HOTP & TOTP] QRCode Builder

### DIFF
--- a/internal/otpverifier/example/run.go
+++ b/internal/otpverifier/example/run.go
@@ -50,7 +50,7 @@ func main() {
 	uuid := uuid.Must(uuid.NewRandom())
 
 	// Create a custom QR code configuration
-	qrCodeConfig := otpverifier.QRCodeConfig{
+	verifier.QRCodeBuilder = otpverifier.QRCodeConfig{
 		Level:              qrcode.Medium,
 		Size:               size,
 		DisableBorder:      true,
@@ -62,7 +62,7 @@ func main() {
 		BottomTextPosition: image.Point{X: size / 2, Y: size + textHeight/3}, // Dynamically calculated
 	}
 
-	err := verifier.SaveQRCodeImage(issuer, accountName, filename, qrCodeConfig)
+	err := verifier.SaveQRCodeImage(issuer, accountName, filename)
 	if err != nil {
 		fmt.Println("Error saving QR code image:", err)
 		return

--- a/internal/otpverifier/hotp.go
+++ b/internal/otpverifier/hotp.go
@@ -24,6 +24,7 @@ type HOTPVerifier struct {
 	counterMismatches int
 	lastResyncTime    time.Time
 	resyncInterval    time.Duration
+	QRCodeBuilder     QRCodeConfig
 }
 
 // NewHOTPVerifier creates a new HOTPVerifier with the given configuration.
@@ -92,6 +93,7 @@ func NewHOTPVerifier(config ...Config) *HOTPVerifier {
 		Hotp:           hotp,
 		recentCounters: recentCounters, // Assign the ring, which may be nil or an actual ring
 		resyncInterval: c.ResyncWindowDelay,
+		QRCodeBuilder:  DefaultQRCodeConfig,
 	}
 }
 

--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -566,7 +566,7 @@ func TestTOTPVerifier_BuildQRCode(t *testing.T) {
 	accountName := "TestAccount"
 
 	// Create a custom QR code configuration
-	qrCodeConfig := otpverifier.QRCodeConfig{
+	verifier.QRCodeBuilder = otpverifier.QRCodeConfig{
 		Level:         qrcode.Medium,
 		Size:          256,
 		DisableBorder: true,
@@ -574,7 +574,7 @@ func TestTOTPVerifier_BuildQRCode(t *testing.T) {
 		BottomText:    "OTP QR Code",
 	}
 
-	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName, qrCodeConfig)
+	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName)
 	if err != nil {
 		t.Errorf("Failed to build QR code: %v", err)
 	}
@@ -604,7 +604,7 @@ func TestTOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	filename := "test_qrcode.png"
 
 	// Test case 1: File path not provided (default)
-	err := verifier.SaveQRCodeImage(issuer, accountName, filename, otpverifier.DefaultQRCodeConfig)
+	err := verifier.SaveQRCodeImage(issuer, accountName, filename)
 	if err != nil {
 		t.Errorf("Failed to save QR code image: %v", err)
 	}
@@ -626,7 +626,7 @@ func TestTOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	qrCodeConfig := otpverifier.DefaultQRCodeConfig
 	qrCodeConfig.FilePath = tempDir
 
-	err = verifier.SaveQRCodeImage(issuer, accountName, filename, qrCodeConfig)
+	err = verifier.SaveQRCodeImage(issuer, accountName, filename)
 	if err != nil {
 		t.Errorf("Failed to save QR code image: %v", err)
 	}
@@ -655,7 +655,7 @@ func TestTOTPVerifier_BuildQRCodeWithCustomParams(t *testing.T) {
 	accountName := "TestAccount"
 
 	// Create a custom QR code configuration
-	qrCodeConfig := otpverifier.QRCodeConfig{
+	verifier.QRCodeBuilder = otpverifier.QRCodeConfig{
 		Level:         qrcode.Medium,
 		Size:          256,
 		DisableBorder: true,
@@ -663,7 +663,7 @@ func TestTOTPVerifier_BuildQRCodeWithCustomParams(t *testing.T) {
 		BottomText:    "OTP QR Code",
 	}
 
-	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName, qrCodeConfig)
+	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName)
 	if err != nil {
 		t.Errorf("Failed to build QR code: %v", err)
 	}
@@ -694,7 +694,7 @@ func TestTOTPVerifier_BuildQRCodePanic(t *testing.T) {
 	accountName := ""
 
 	// Create a custom QR code configuration
-	qrCodeConfig := otpverifier.QRCodeConfig{
+	verifier.QRCodeBuilder = otpverifier.QRCodeConfig{
 		Level:           qrcode.Medium,
 		Size:            256,
 		DisableBorder:   true,
@@ -717,7 +717,7 @@ func TestTOTPVerifier_BuildQRCodePanic(t *testing.T) {
 		}()
 
 		// Call BuildQRCode with maximum digits, which should panic
-		verifier.BuildQRCode("issuer", "accountName", qrCodeConfig)
+		verifier.BuildQRCode("issuer", "accountName")
 	})
 
 	// Expect a panic when calling BuildQRCode with empty issuer
@@ -734,7 +734,7 @@ func TestTOTPVerifier_BuildQRCodePanic(t *testing.T) {
 		}()
 
 		// Call BuildQRCode with an empty issuer, which should panic
-		verifier.BuildQRCode(issuer, "accountName", qrCodeConfig)
+		verifier.BuildQRCode(issuer, "accountName")
 	})
 
 	// Expect a panic when calling BuildQRCode with empty account name
@@ -751,7 +751,7 @@ func TestTOTPVerifier_BuildQRCodePanic(t *testing.T) {
 		}()
 
 		// Call BuildQRCode with an empty account name, which should panic
-		verifier.BuildQRCode("issuer", accountName, qrCodeConfig)
+		verifier.BuildQRCode("issuer", accountName)
 	})
 
 }
@@ -769,7 +769,7 @@ func TestHOTPVerifier_BuildQRCode(t *testing.T) {
 	accountName := "TestAccount"
 
 	// Create a custom QR code configuration
-	qrCodeConfig := otpverifier.QRCodeConfig{
+	verifier.QRCodeBuilder = otpverifier.QRCodeConfig{
 		Level:           qrcode.Medium,
 		Size:            256,
 		DisableBorder:   true,
@@ -778,7 +778,7 @@ func TestHOTPVerifier_BuildQRCode(t *testing.T) {
 		ForegroundColor: color.Black,
 	}
 
-	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName, qrCodeConfig)
+	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName)
 	if err != nil {
 		t.Errorf("Failed to build QR code: %v", err)
 	}
@@ -808,7 +808,7 @@ func TestHOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	filename := "test_hotp_qrcode.png"
 
 	// Test case 1: File path not provided (default)
-	err := verifier.SaveQRCodeImage(issuer, accountName, filename, otpverifier.DefaultQRCodeConfig)
+	err := verifier.SaveQRCodeImage(issuer, accountName, filename)
 	if err != nil {
 		t.Errorf("Failed to save QR code image: %v", err)
 	}
@@ -827,10 +827,9 @@ func TestHOTPVerifier_SaveQRCodeImage(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	qrCodeConfig := otpverifier.DefaultQRCodeConfig
-	qrCodeConfig.FilePath = tempDir
+	verifier.QRCodeBuilder.FilePath = tempDir
 
-	err = verifier.SaveQRCodeImage(issuer, accountName, filename, qrCodeConfig)
+	err = verifier.SaveQRCodeImage(issuer, accountName, filename)
 	if err != nil {
 		t.Errorf("Failed to save QR code image: %v", err)
 	}
@@ -859,7 +858,7 @@ func TestHOTPVerifier_BuildQRCodeWithCustomParams(t *testing.T) {
 	accountName := "TestAccount"
 
 	// Create a custom QR code configuration
-	qrCodeConfig := otpverifier.QRCodeConfig{
+	verifier.QRCodeBuilder = otpverifier.QRCodeConfig{
 		Level:           qrcode.Medium,
 		Size:            256,
 		DisableBorder:   true,
@@ -868,7 +867,7 @@ func TestHOTPVerifier_BuildQRCodeWithCustomParams(t *testing.T) {
 		ForegroundColor: color.Black,
 	}
 
-	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName, qrCodeConfig)
+	qrCodeBytes, err := verifier.BuildQRCode(issuer, accountName)
 	if err != nil {
 		t.Errorf("Failed to build QR code: %v", err)
 	}
@@ -898,7 +897,7 @@ func TestHOTPVerifier_BuildQRCodePanic(t *testing.T) {
 	accountName := ""
 
 	// Create a custom QR code configuration
-	qrCodeConfig := otpverifier.QRCodeConfig{
+	verifier.QRCodeBuilder = otpverifier.QRCodeConfig{
 		Level:           qrcode.Medium,
 		Size:            256,
 		DisableBorder:   true,
@@ -921,7 +920,7 @@ func TestHOTPVerifier_BuildQRCodePanic(t *testing.T) {
 		}()
 
 		// Call BuildQRCode with maximum digits, which should panic
-		verifier.BuildQRCode("issuer", "accountName", qrCodeConfig)
+		verifier.BuildQRCode("issuer", "accountName")
 	})
 
 	// Expect a panic when calling BuildQRCode with empty issuer
@@ -938,7 +937,7 @@ func TestHOTPVerifier_BuildQRCodePanic(t *testing.T) {
 		}()
 
 		// Call BuildQRCode with an empty issuer, which should panic
-		verifier.BuildQRCode(issuer, "accountName", qrCodeConfig)
+		verifier.BuildQRCode(issuer, "accountName")
 	})
 
 	// Expect a panic when calling BuildQRCode with empty account name
@@ -955,7 +954,7 @@ func TestHOTPVerifier_BuildQRCodePanic(t *testing.T) {
 		}()
 
 		// Call BuildQRCode with an empty account name, which should panic
-		verifier.BuildQRCode("issuer", accountName, qrCodeConfig)
+		verifier.BuildQRCode("issuer", accountName)
 	})
 
 }

--- a/internal/otpverifier/qrcode_builder.go
+++ b/internal/otpverifier/qrcode_builder.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BuildQRCode generates a QR code image for the OTP configuration.
-func (v *TOTPVerifier) BuildQRCode(issuer, accountName string, config QRCodeConfig) ([]byte, error) {
+func (v *TOTPVerifier) BuildQRCode(issuer, accountName string) ([]byte, error) {
 	// Check if issuer or account name is empty
 	if issuer == "" {
 		panic("BuildQRCode: issuer cannot be empty")
@@ -25,22 +25,19 @@ func (v *TOTPVerifier) BuildQRCode(issuer, accountName string, config QRCodeConf
 		panic("BuildQRCode: maximum digits are 8 for TOTP")
 	}
 
-	// Ensure the configuration has default values where needed
-	config = ensureDefaultConfig(config)
-
 	otpURL := v.GenerateOTPURL(issuer, accountName)
-	qrCodeImage, err := config.GenerateQRCodeImage(otpURL)
+	qrCodeImage, err := v.QRCodeBuilder.GenerateQRCodeImage(otpURL)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return config.encodeImageToPNGBytes(qrCodeImage.(*image.RGBA))
+	return v.QRCodeBuilder.encodeImageToPNGBytes(qrCodeImage.(*image.RGBA))
 }
 
 // SaveQRCodeImage saves the QR code image to a file.
-func (v *TOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string, config QRCodeConfig) error {
-	qrCodeBytes, err := v.BuildQRCode(issuer, accountName, config)
+func (v *TOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string) error {
+	qrCodeBytes, err := v.BuildQRCode(issuer, accountName)
 	if err != nil {
 		return err
 	}
@@ -50,7 +47,7 @@ func (v *TOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string, con
 	// Note: There is no explicit (e.g., strict permission) requirement for the file path,
 	// so it basically depends on the use case and any specific permission requirements.
 	// Also, keep in mind that if running on Windows, long file paths are not allowed by default.
-	filePath := config.FilePath
+	filePath := v.QRCodeBuilder.FilePath
 	if filePath == "" {
 		filePath = "."
 	}
@@ -69,8 +66,8 @@ func (v *TOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string, con
 }
 
 // SaveQRCodeImage saves the QR code image to a file.
-func (v *HOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string, config QRCodeConfig) error {
-	qrCodeBytes, err := v.BuildQRCode(issuer, accountName, config)
+func (v *HOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string) error {
+	qrCodeBytes, err := v.BuildQRCode(issuer, accountName)
 	if err != nil {
 		return err
 	}
@@ -80,7 +77,7 @@ func (v *HOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string, con
 	// Note: There is no explicit (e.g., strict permission) requirement for the file path,
 	// so it basically depends on the use case and any specific permission requirements.
 	// Also, keep in mind that if running on Windows, long file paths are not allowed by default.
-	filePath := config.FilePath
+	filePath := v.QRCodeBuilder.FilePath
 	if filePath == "" {
 		filePath = "."
 	}
@@ -99,7 +96,7 @@ func (v *HOTPVerifier) SaveQRCodeImage(issuer, accountName, filename string, con
 }
 
 // BuildQRCode generates a QR code image for the OTP configuration.
-func (v *HOTPVerifier) BuildQRCode(issuer, accountName string, config QRCodeConfig) ([]byte, error) {
+func (v *HOTPVerifier) BuildQRCode(issuer, accountName string) ([]byte, error) {
 	// Check if issuer or account name is empty
 	if issuer == "" {
 		panic("BuildQRCode: issuer cannot be empty")
@@ -113,15 +110,12 @@ func (v *HOTPVerifier) BuildQRCode(issuer, accountName string, config QRCodeConf
 		panic("BuildQRCode: maximum digits are 8 for HOTP")
 	}
 
-	// Ensure the configuration has default values where needed
-	config = ensureDefaultConfig(config)
-
 	otpURL := v.GenerateOTPURL(issuer, accountName)
-	qrCodeImage, err := config.GenerateQRCodeImage(otpURL)
+	qrCodeImage, err := v.QRCodeBuilder.GenerateQRCodeImage(otpURL)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return config.encodeImageToPNGBytes(qrCodeImage.(*image.RGBA))
+	return v.QRCodeBuilder.encodeImageToPNGBytes(qrCodeImage.(*image.RGBA))
 }

--- a/internal/otpverifier/totp.go
+++ b/internal/otpverifier/totp.go
@@ -20,6 +20,7 @@ type TOTPVerifier struct {
 	totp            *gotp.TOTP
 	UsedTokens      *sync.Map
 	CleanupInterval int
+	QRCodeBuilder   QRCodeConfig
 }
 
 // NewTOTPVerifier creates a new TOTPVerifier with the given configuration.
@@ -70,6 +71,7 @@ func NewTOTPVerifier(config ...Config) *TOTPVerifier {
 		// Without implementing a synchronization window similar to HOTP, it can lead to high vulnerability.
 		UsedTokens:      &sync.Map{},
 		CleanupInterval: c.CleanupInterval,
+		QRCodeBuilder:   DefaultQRCodeConfig,
 	}
 
 	// Start the periodic cleanup goroutine


### PR DESCRIPTION
- [+] refactor(otpverifier): move QRCodeConfig to be a field of TOTPVerifier and HOTPVerifier structs
- [+] refactor(otpverifier): update BuildQRCode and SaveQRCodeImage methods to use the QRCodeBuilder field
- [+] test(otpverifier): update tests to set QRCodeBuilder field instead of passing QRCodeConfig as a parameter
- [+] refactor(example): update example code to set QRCodeBuilder field instead of passing QRCodeConfig as a parameter