### PR TITLE
Docs [TOTP & OCRA] Update Comment

### DIFF
--- a/internal/otpverifier/hotp_ocra.go
+++ b/internal/otpverifier/hotp_ocra.go
@@ -103,6 +103,7 @@ func (v *OCRAVerifier) GenerateToken(challenge string) string {
 // generateOCRA generates an OCRA token using the specified hash algorithm.
 func (v *OCRAVerifier) generateOCRA(counter uint64, question string, hash func() hash.Hash) string {
 	// Prepare the input data
+	//
 	// Note: The counter and counter are not just any values. They can be bound to a cryptographically secure pseudorandom number,
 	// along with question, similar to how [DecodeBase32WithPadding] is used to manipulate the result in the frontend hahaha.
 	var data []byte

--- a/internal/otpverifier/totp.go
+++ b/internal/otpverifier/totp.go
@@ -184,7 +184,8 @@ func (v *TOTPVerifier) verifyWithSignature(token, signature string) bool {
 
 // GenerateToken generates a token for the current time.
 func (v *TOTPVerifier) GenerateToken() string {
-	// TODO: Allow customizing the character set instead of using only numbers.
+	// TODO: Allow customizing the character set instead of using only numbers
+	// (e.g., based on ciphertext cryptography, depending on the client apps' capability to handle Unicode, such as using ciphertext from ancient Egypt).
 	// Although the current TOTP implementation relies on time and is secure due to the use of the [crypto/subtle] package,
 	// even with the current implementation that uses numbers, it is secure, especially against brute-force and timing attacks.
 	// However, we won't implement this now because most 2FA apps in the world, especially for mobile devices,
@@ -194,7 +195,8 @@ func (v *TOTPVerifier) GenerateToken() string {
 
 // GenerateTokenWithSignature generates a token and signature for the current time.
 func (v *TOTPVerifier) GenerateTokenWithSignature() (string, string) {
-	// TODO: Allow customizing the character set instead of using only numbers.
+	// TODO: Allow customizing the character set instead of using only numbers
+	// (e.g., based on ciphertext cryptography, depending on the client apps' capability to handle Unicode, such as using ciphertext from ancient Egypt).
 	// Although the current TOTP implementation relies on time and is secure due to the use of the [crypto/subtle] package,
 	// even with the current implementation that uses numbers, it is secure, especially against brute-force and timing attacks.
 	// However, we won't implement this now because most 2FA apps in the world, especially for mobile devices,


### PR DESCRIPTION
- [+] docs(otpverifier): add comments about potential future improvements for OCRA and TOTP token generation
- [+] The comments mention:
- [+] For OCRA, the counter and question values could be bound to a cryptographically secure pseudorandom number
- [+] For TOTP, the character set could be customized beyond just numbers, potentially using ciphertext cryptography. However, this is not being implemented now for compatibility with existing 2FA apps.