### PR TITLE
Increase wait time for unpredictable test execution

### DIFF
--- a/internal/otpverifier/otpverifier_test.go
+++ b/internal/otpverifier/otpverifier_test.go
@@ -199,7 +199,10 @@ func TestTOTPVerifier_PeriodicCleanup(t *testing.T) {
 	verifier.Verify(token1)
 
 	// Wait Assistant garbage collector for periodic cleanup to occur (less than the token validity period)
-	time.Sleep(time.Duration(period*4/4) * time.Second)
+	// Increase the wait time to account for unpredictable test execution, as it may not be synchronized in test mode
+	// (literally challenging to make tests predictable in test mode, and it's not even necessary for synchronization in test mode),
+	// however, in production, this should be synchronized
+	time.Sleep(time.Duration(period*6/5) * time.Second)
 
 	// Simulate used tokens
 	token2 := verifier.GenerateToken()


### PR DESCRIPTION
- [+] test(otpverifier): increase wait time for periodic cleanup in test mode
- [+] Increase the wait time for periodic cleanup in the test to account for unpredictable test execution
- [+] The test execution may not be synchronized in test mode, making it challenging to ensure predictable results
- [+] However, in production, the periodic cleanup should be properly synchronized
- [+] Adjust the wait time from `period*4/4` to `period*6/5` seconds to provide more leeway for the cleanup to occur